### PR TITLE
Hot Fix: Pod Communication Error

### DIFF
--- a/kubeadm.sh
+++ b/kubeadm.sh
@@ -16,4 +16,36 @@ sleep 3
 echo -e "\n\n# kubectl alias\nalias k='kubectl'" >> ~/.bashrc
 
 sleep 3
-kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
+kubectl apply -f http://www.eg-playground.xyz:5922/calico.yaml
+sleep 10
+
+kubectl get configmap kube-proxy -n kube-system -o yaml > kube-proxy.yaml
+sed -i "s/strictARP: false/strictARP: true/g" kube-proxy.yaml
+kubectl apply -f kube-proxy.yaml
+
+sudo cat <<EOF > metallb-ippool.yaml
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: first-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 10.0.0.200-10.0.0.250
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - first-pool
+EOF
+
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
+
+sleep 10
+kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+kubectl delete validatingwebhookconfigurations metallb-webhook-configuration
+kubectl apply -f metallb-ippool.yaml


### PR DESCRIPTION
Pod Communication Error Fixed
- Install Calico cni instead of Flannel cni
- Install MetalLB
  - Prerequisites: Terraform, dhcp of private subnet must not include after 10.0.0.200